### PR TITLE
Print the Ruby description constant on boot

### DIFF
--- a/bin/bench
+++ b/bin/bench
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+puts RUBY_DESCRIPTION
+
 # Usage:
 #   WARMUP=0 BENCHMARK=10000 bin/bench
 #   PROFILE=wall INTERVAL=100 WARMUP=1 BENCHMARK=1000 bin/bench


### PR DESCRIPTION
I want to see what version of Ruby I'm running with when I use this
benchmark so that I can compare Ruby versions.

Typically I would run with `ruby -v` so that I can see the version
information.  But `-v` also enables warnings, and I'm afraid that will
impact the benchmark results.